### PR TITLE
Text Color Changes and Crash Fix Windows

### DIFF
--- a/rkdeveloptool-gui/rkdevtoolgui.py
+++ b/rkdeveloptool-gui/rkdevtoolgui.py
@@ -648,14 +648,14 @@ class RKDevToolGUI(QMainWindow):
             # Parse chip info to show readable chip name
             chip_text = parse_chip_info(self.chip_info) if self.chip_info else self.tr('unknown_chip')
             self.device_status_label.setText(mode_text)
-            self.device_status_label.setStyleSheet("QLabel { color: #28a745; padding: 5px; font-weight: bold; }")
+            self.device_status_label.setStyleSheet("QLabel { padding: 5px; }")
             self.chip_info_label.setText(f"{self.tr('chip')}: {chip_text}")
             self.statusBar().showMessage(f"{self.tr('ready_status')}{self.tr('status_line_delimiter')}{mode_text}")
             self.connection_status.setText(f"{self.tr('connected')}")
             self._update_home_banner(True, f"{mode_text} · {self.tr('chip')}: {chip_text}")
         else:
             self.device_status_label.setText(self.tr("detecting_device"))
-            self.device_status_label.setStyleSheet("QLabel { color: #aaaaaa; padding: 5px; }")
+            self.device_status_label.setStyleSheet("QLabel { padding: 5px; }")
             self.chip_info_label.setText(f"{self.tr('chip')}: {self.tr('unknown_chip')}")
             self.statusBar().showMessage(
                 f"{self.tr('ready_status')}{self.tr('status_line_delimiter')}{self.tr('not_connected_status')}")
@@ -969,7 +969,6 @@ def main():
             manager.tr("tool_not_found_title"),
             manager.tr("tool_not_found_message")
         )
-        sys.exit(1)
 
     # Launch GUI
     manager = TranslationManager()

--- a/rkdeveloptool-gui/themes.py
+++ b/rkdeveloptool-gui/themes.py
@@ -162,6 +162,33 @@ class ThemeManager:
             palette = create_dark_palette()
 
         self.app.setPalette(palette)
+        for widget in self.app.allWidgets():
+            widget.setPalette(palette)
+            widget.update()
+
+        if self.current_theme == self.LIGHT:
+            placeholder_color = "rgba(0, 0, 0, 120)"
+        else:
+            placeholder_color = "rgba(255, 255, 255, 120)"
+
+        if self.current_theme == self.LIGHT:
+            placeholder_color = "rgba(0, 0, 0, 120)"
+            text_color = "#282828"
+            bg_color = "#ffffff"
+        else:
+            placeholder_color = "rgba(255, 255, 255, 120)"
+            text_color = "#ffffff"
+            bg_color = "#1e1e1e"
+
+        self.app.setStyleSheet(f"""
+            QLineEdit {{
+                color: {text_color};
+                background-color: {bg_color};
+            }}
+            QLineEdit::placeholder {{
+                color: {placeholder_color};
+            }}
+        """)
     
     def set_style(self, style_name):
         """Set a specific style"""
@@ -320,7 +347,13 @@ class ThemeAutoManager:
         elif self.platform.startswith("linux"):
             return self._get_linux_theme()
         else:
-            return "light"
+            try:
+                import winreg
+                key = winreg.OpenKey(winreg.HKEY_CURRENT_USER, r"Software\Microsoft\Windows\CurrentVersion\Themes\Personalize")
+                value, _ = winreg.QueryValueEx(key, "AppsUseLightTheme")
+                return "light" if value == 1 else "dark"
+            except Exception:
+                return "light"
     
     def apply_system_theme(self):
         """Apply system theme to the application"""

--- a/rkdeveloptool-gui/ui_panels.py
+++ b/rkdeveloptool-gui/ui_panels.py
@@ -37,7 +37,8 @@ def create_home_tab(gui):
 
     # Task cards
     cards_label = QLabel()
-    cards_label.setStyleSheet("QLabel { font-weight: bold; padding: 6px 2px; }")
+    cards_label.setStyleSheet("")
+    cards_label.setFont(cards_label.font())
     layout.addWidget(cards_label)
 
     cards_grid = QGridLayout()
@@ -104,10 +105,10 @@ def create_device_panel(gui):
     layout = QVBoxLayout()
 
     status_label = QLabel()
-    status_label.setStyleSheet("QLabel { color: #aaaaaa; padding: 5px; }")
+    status_label.setStyleSheet("QLabel { padding: 5px; }")
 
     chip_label = QLabel()
-    chip_label.setStyleSheet("QLabel { color: #f0f0f0; font-weight: bold; padding: 5px; }")
+    chip_label.setStyleSheet("QLabel { font-weight: bold; padding: 5px; }")
 
     devices_label = QLabel()
 


### PR DESCRIPTION
Fixed several UI bugs:

- Labels invisible in light mode due to hardcoded near-white colors (chip label, cards label)
- Placeholder text in input fields unreadable in dark mode (black text on dark background)
- App crashed on startup when rkdeveloptool not installed instead of showing warning and continuing
- Added Windows system theme detection for auto theme mode
- Force repaint all widgets when switching themes so colors update immediately